### PR TITLE
make browserify ignore os and rimraf

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,10 @@
     "leveldown": "~0.6.1",
     "memdown": "~0.2.0"
   },
+  "browser": {
+    "os": false,
+    "rimraf": false
+  },
   "devDependencies": {
     "tape": "~1.0.2"
   },


### PR DESCRIPTION
eventually this should have a `browser.js`, but for now this works in the browser as long as you're only using Memdown.
