### PR TITLE
Fix options clobber for creating new leveldb instance.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ in-memory/
 level-test/
 .tern-port
 npm-debug.log
+.DS_Store

--- a/index.js
+++ b/index.js
@@ -3,10 +3,11 @@ var Memdown = require('memdown')
 var rimraf = require('rimraf')
 var tmpdir = require('osenv').tmpdir()
 var path = require('path')
+var xtend = require('xtend')
 function disk (opts) {
   var leveldown = require('leveldown')
   return function (name, _opts, cb) {
-    _opts = opts || {}
+    _opts = xtend(opts, _opts)
     name = name || 'db_' + Date.now()
     var dir = path.join(tmpdir, name)
     if(opts.clean !== false)

--- a/package.json
+++ b/package.json
@@ -9,14 +9,15 @@
   },
   "dependencies": {
     "level-js": "~1.0.8",
-    "rimraf": "~2.2.2",
+    "rimraf": "~2.2.6",
     "osenv": "0.0.3",
-    "memdown": "~0.5.1",
+    "memdown": "~0.6.0",
     "levelup": "~0.18.2",
-    "leveldown": "~0.10.2"
+    "leveldown": "~0.10.2",
+    "xtend": "~2.1.2"
   },
   "devDependencies": {
-    "tape": "~2.1.0"
+    "tape": "~2.4.0"
   },
   "scripts": {
     "test": "set -e; for t in test/*.js; do node $t; done"

--- a/test/index.js
+++ b/test/index.js
@@ -24,3 +24,18 @@ test('default name', function (t) {
     t.end()
   })
 })
+
+test('options (valueEncoding: json)', function (t) {
+  var db = level('level-test2', {valueEncoding: 'json'})
+  var key = ''+Math.random()
+  var value = {test_key: '' + new Date()}
+
+  db.put(key, value, function (err) {
+    t.notOk(err)
+
+    db.get(key, function (err, _value) {
+      t.deepEqual(_value, value)
+      t.end()
+    })
+  })
+})


### PR DESCRIPTION
A recent change started clobbering the options specified when creating a database instance.

Changed to merge options specified.

Added a test & updated dependencies.
