### PR TITLE
Dedup code between node and browser

### DIFF
--- a/browser.js
+++ b/browser.js
@@ -1,52 +1,22 @@
 'use strict'
 
-var packager = require('level-packager')
 var leveljs = require('level-js')
-var memdown = require('memdown')
-var xtend = require('xtend')
+var wrap = require('./wrap')
 
-function wrap (down, parentOpts) {
-  var levelup = packager(down)
+function getDown () {
+  return leveljs
+}
 
-  return function (loc, opts, cb) {
-    if (typeof loc === 'function') { // (cb)
-      cb = loc
-      loc = null
-      opts = null
-    } else if (typeof loc === 'object' && loc !== null) { // (opts[, cb])
-      cb = opts
-      opts = loc
-      loc = null
-    } else if (typeof opts === 'function') { // (name, cb)
-      cb = opts
-      opts = null
-    }
+function getLocation (name) {
+  return name
+}
 
-    opts = xtend(parentOpts, opts)
-
-    if (!parentOpts.mem) {
-      loc = loc || 'db_' + Date.now()
-
-      if (opts.clean !== false && typeof down.destroy === 'function') {
-        down.destroy(loc, function () {
-          // TODO: this must be finished before we open the new db
-        })
-      }
-    }
-
-    // Note: memdown ignores loc
-    return levelup(loc, opts, cb)
+function clean (location, down) {
+  if (typeof down.destroy === 'function') {
+    down.destroy(location, function () {
+      // TODO: this must be finished before we open the new db
+    })
   }
 }
 
-module.exports = function (down, opts) {
-  if (typeof down !== 'function') {
-    opts = down
-    down = null
-  }
-
-  opts = xtend(opts)
-  down = down || (opts.mem ? memdown : leveljs)
-
-  return wrap(down, opts)
-}
+module.exports = wrap(getDown, getLocation, clean)

--- a/index.js
+++ b/index.js
@@ -1,63 +1,29 @@
 'use strict'
 
-var packager = require('level-packager')
 var memdown = require('memdown')
 var rimraf = require('rimraf')
 var mkdirp = require('mkdirp')
 var tmpdir = require('osenv').tmpdir()
 var path = require('path')
-var xtend = require('xtend')
+var wrap = require('./wrap')
 
-function getDown (opts) {
+function getDown (defaults) {
   try {
     return require('leveldown')
   } catch (err) {
     console.error('could not require leveldown, fallback to memdown')
-
-    opts.mem = true
+    defaults.mem = true
     return memdown
   }
 }
 
-function wrap (down, parentOpts) {
-  var levelup = packager(down)
-
-  return function (loc, opts, cb) {
-    if (typeof loc === 'function') { // (cb)
-      cb = loc
-      loc = null
-      opts = null
-    } else if (typeof loc === 'object' && loc !== null) { // (opts[, cb])
-      cb = opts
-      opts = loc
-      loc = null
-    } else if (typeof opts === 'function') { // (name, cb)
-      cb = opts
-      opts = null
-    }
-
-    opts = xtend(parentOpts, opts)
-
-    if (!parentOpts.mem) {
-      loc = loc || 'db_' + Date.now()
-      mkdirp.sync(tmpdir)
-      loc = path.join(tmpdir, loc)
-      if (opts.clean !== false) rimraf.sync(loc)
-    }
-
-    // Note: memdown ignores loc
-    return levelup(loc, opts, cb)
-  }
+function getLocation (name) {
+  mkdirp.sync(tmpdir)
+  return path.join(tmpdir, name)
 }
 
-module.exports = function (down, opts) {
-  if (typeof down !== 'function') {
-    opts = down
-    down = null
-  }
-
-  opts = xtend(opts)
-  down = down || (opts.mem ? memdown : getDown(opts))
-
-  return wrap(down, opts)
+function clean (location) {
+  rimraf.sync(location)
 }
+
+module.exports = wrap(getDown, getLocation, clean)

--- a/wrap.js
+++ b/wrap.js
@@ -1,0 +1,44 @@
+'use strict'
+
+var packager = require('level-packager')
+var memdown = require('memdown')
+var xtend = require('xtend')
+
+module.exports = function (getDown, getLocation, clean) {
+  return function factory (down, defaults) {
+    if (typeof down !== 'function') {
+      defaults = down
+      down = null
+    }
+
+    defaults = xtend(defaults)
+    down = down || (defaults.mem ? memdown : getDown(defaults))
+
+    var levelup = packager(down)
+
+    return function ctor (name, opts, callback) {
+      if (typeof name === 'function') {
+        callback = name
+        name = opts = null
+      } else if (typeof name === 'object' && name !== null) {
+        callback = opts
+        opts = name
+        name = null
+      } else if (typeof opts === 'function') {
+        callback = opts
+        opts = null
+      }
+
+      opts = xtend(defaults, opts)
+
+      if (defaults.mem) {
+        var location = ''
+      } else {
+        location = getLocation(name || 'db_' + Date.now())
+        if (opts.clean !== false) clean(location, down)
+      }
+
+      return levelup(location, opts, callback)
+    }
+  }
+}


### PR DESCRIPTION
As an alternative to #68. Not sure I like it though, I somehow feel the previous version was easier to follow.

No functional change except: if `opts.mem` is true, location is always an empty string.